### PR TITLE
Switch --help output to dumping ACTION keys

### DIFF
--- a/livefs_edit/__main__.py
+++ b/livefs_edit/__main__.py
@@ -17,23 +17,15 @@ livefs-edit makes modifications to Ubuntu live ISOs.
 
 Actions include:
 
- * --setup-rootfs
- * --shell
- * --cp
- * --inject-snap
- * --edit-squashfs
- * --add-cmdline-arg
- * --add-autoinstall-config
- * --add-debs-to-pool
- * --add-packages-to-pool
- * --unpack-initrd
-
 """
 
 
 def main(argv):
     if '--help' in argv:
         print(HELP_TXT)
+        for action in sorted(ACTIONS.keys()):
+            print(f" * --{action.replace('_', '-')}")
+        print()
         sys.exit(0)
 
     isopath = argv[0]


### PR DESCRIPTION
The current --help output is incorrect as new actions have been
added to the code.  Instead of keeping a static string up-to-date
generate the action flags by transforming the registered keys.