### PR TITLE
Retrieve Suite (dist version)

### DIFF
--- a/livefs_edit/actions.py
+++ b/livefs_edit/actions.py
@@ -333,7 +333,7 @@ def add_autoinstall_config(ctxt, autoinstall_config):
 
 
 @register_action()
-def resign_pool(ctxt, dist='stable'):
+def resign_pool(ctxt, dist=None):
     gpgconf = ctxt.tmpfile()
     gpghome = ctxt.tmpdir()
     with open(gpgconf, 'x') as c:
@@ -388,7 +388,7 @@ def add_debs_to_pool(ctxt, debs: List[str] = ()):
     cp = run(
         [
             'apt-ftparchive', '--md5=off', '--sha1=off', '--sha512=off',
-            'release', 'dists/'+dist+'',
+            'release', f'dists/{dist}',
         ],
         cwd=ctxt.p('new/iso'), stdout=subprocess.PIPE)
     # The uncompressed Packages file has to be around when

--- a/livefs_edit/actions.py
+++ b/livefs_edit/actions.py
@@ -351,7 +351,6 @@ Expire-Date: 0
         ['gpg', '--home', gpghome, '--gen-key', '--batch'],
         stdin=gpgconfp)
 
-    print(f'new/iso/dists/{dist}/Release')
     release = ctxt.p(f'new/iso/dists/{dist}/Release')
 
     run(['gpg', '--home', gpghome, '--detach-sign', '--armor', release])

--- a/livefs_edit/context.py
+++ b/livefs_edit/context.py
@@ -184,8 +184,8 @@ class EditContext:
             return fp.read().strip().split()[-2]
 
     def get_suite(self):
-        path=glob.glob('dists/*/Release')
-        suite=path[0].split(os.sep)[1]
+        path=glob.glob(self.p('old/iso/dists/*/Release'))
+        suite=path[0].split(os.sep)[6]
         return suite
 
     def edit_squashfs(self, name, *, add_sys_mounts=True):

--- a/livefs_edit/context.py
+++ b/livefs_edit/context.py
@@ -183,6 +183,12 @@ class EditContext:
         with open(self.p('new/iso/.disk/info')) as fp:
             return fp.read().strip().split()[-2]
 
+    def get_suite(self):
+        # Dirty hack to retrieve the suite version
+        with open(self.p('new/iso/.disk/info')) as fp:
+            s = fp.read().strip().split()[-6]
+            return s.replace('"', '').lower()
+
     def edit_squashfs(self, name, *, add_sys_mounts=True):
         lower = self.mount_squash(name)
         target = self.p(f'new/{name}')

--- a/livefs_edit/context.py
+++ b/livefs_edit/context.py
@@ -184,10 +184,9 @@ class EditContext:
             return fp.read().strip().split()[-2]
 
     def get_suite(self):
-        # Dirty hack to retrieve the suite version
-        with open(self.p('new/iso/.disk/info')) as fp:
-            s = fp.read().strip().split()[-6]
-            return s.replace('"', '').lower()
+        path=glob.glob('dists/*/Release')
+        suite=path[0].split(os.sep)[1]
+        return suite
 
     def edit_squashfs(self, name, *, add_sys_mounts=True):
         lower = self.mount_squash(name)


### PR DESCRIPTION
This software assumes `dists/stable` is the default directory where to save new .deb packages, whereas the LiveCD uses `dists/%suite name%` instead.
This commit tries to guess the correct path by looking into `new/iso/.disk/info`.