### PR TITLE
Error handling in cli

### DIFF
--- a/livefs_edit/cli.py
+++ b/livefs_edit/cli.py
@@ -65,7 +65,7 @@ def parse(actions, raw_args):
             a = a[2:]
             try:
                 func = actions[a]
-            except AttributeError:
+            except KeyError:
                 raise ArgException(f"unknown action {a!r}")
         elif func is None:
             raise ArgException(f"no action specified for {a!r}")

--- a/livefs_edit/cli.py
+++ b/livefs_edit/cli.py
@@ -68,7 +68,7 @@ def parse(actions, raw_args):
             except AttributeError:
                 raise ArgException(f"unknown action {a!r}")
         elif func is None:
-            1/0
+            raise ArgException(f"no action specified for {a!r}")
         else:
             func_args.append(a)
 

--- a/livefs_edit/cli.py
+++ b/livefs_edit/cli.py
@@ -66,7 +66,7 @@ def parse(actions, raw_args):
             try:
                 func = actions[a]
             except AttributeError:
-                raise ArgException("unknown action {a!r}")
+                raise ArgException(f"unknown action {a!r}")
         elif func is None:
             1/0
         else:


### PR DESCRIPTION
cli.py: format strings must start with 'f"'
cli.py: provide proper exception for missing command
cli.py: missing dictionary key raises KeyError
