### PR TITLE
context: on error use lazy umount

### DIFF
--- a/livefs_edit/context.py
+++ b/livefs_edit/context.py
@@ -215,7 +215,10 @@ class EditContext:
     def teardown(self):
         for mount in reversed(self._mounts):
             run(['mount', '--make-rprivate', mount])
-            run(['umount', '-R', mount])
+            try:
+                run(['umount', '-R', mount])
+            except subprocess.CalledProcessError:
+                run(['umount', '-l', mount])
         shutil.rmtree(self.dir)
         for loop in reversed(self._loops):
             run(['losetup', '--detach', loop])


### PR DESCRIPTION
Closes: #25

When running kernel-replace 'umount -R' tends to fail. Catch the exception and use 'umount -l' in that case.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>