### PR TITLE
main: help when not enough args have been supplied

### DIFF
--- a/livefs_edit/__main__.py
+++ b/livefs_edit/__main__.py
@@ -41,7 +41,7 @@ Actions include:
 def main(argv=None):
     if argv is None:
         argv = sys.argv[1:]
-    if '--help' in argv:
+    if '--help' in argv or len(argv) < 3:
         print(HELP_TXT)
         for action in sorted(ACTIONS.keys()):
             print(f" * --{action.replace('_', '-')}")


### PR DESCRIPTION
main assumes that at least 3 arguments have been supplied.  Anything less than that, show usage instead.  This particularly nice for just invoking with no arguments.