### PR TITLE
Adds support for adding specific versions of packages to pool

### DIFF
--- a/livefs_edit/actions.py
+++ b/livefs_edit/actions.py
@@ -481,7 +481,13 @@ def add_packages_to_pool(ctxt, packages: List[str]):
     cache.open()
     for p in packages:
         with ctxt.logged(f'marking {p} for installation'):
-            cache[p].mark_install()
+            if "=" in p:
+                package_name, package_version = p.split("=")
+                package = cache[package_name]
+                package.candidate = package.versions.get(package_version)
+                package.mark_install()
+            else:
+                cache[p].mark_install()
     debs = download_missing_pool_debs(ctxt, cache)
     add_debs_to_pool(ctxt, debs=debs)
 


### PR DESCRIPTION
Solves #21

Allows adding packages with of a specific version by using `=` like in [autoinstall](https://ubuntu.com/server/docs/install/autoinstall-reference) and apt