### PR TITLE
setup: declare pyyaml depend

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,8 @@ classifiers =
 [options]
 packages = find:
 python_requires = >=3.6
+install_requires =
+    PyYAML
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Declare the pyyaml dependency.  This is required to allow 'pipx install' to produce a working result.