### PR TITLE
actions: add cp-to-base and rm-from-base

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,21 @@ relative to the main temporary directory. So something like this:
 
 to replace the initrd.
 
+### cp-to-base
+
+**argument**: `source`
+
+**argument**: `dest`
+
+Copy a file to the base image. If `source` is relative it is
+assumed to be relative to the main temporary directory.
+
+```
+--cp /etc/apt/sources.list.d/ppa.sources etc/apt/sources.list.d/ppa.sources
+```
+
+could be used to add a private ppa.
+
 ### rm
 
 **argument**: `path`
@@ -150,6 +165,18 @@ Remove a file or directory.
 ```
 
 to remove the directory casper.
+
+### rm-from-base
+
+**argument**: `path`
+
+Remove a file or directory from the base image.
+
+```
+--rm etc/apt/sources.list.d/ppa.sources
+```
+
+could be used to remove a ppa.
 
 ### inject-snap
 

--- a/livefs_edit/actions.py
+++ b/livefs_edit/actions.py
@@ -162,6 +162,12 @@ def cp(ctxt, source, dest):
 
 
 @register_action()
+def cp_to_base(ctxt, source, dest):
+    base = ctxt.edit_squashfs(get_squash_names(ctxt)[0])
+    shutil.copy(ctxt.p(source, allow_abs=True), f'{base}/{dest}')
+
+
+@register_action()
 def install_debs(ctxt, debs: List[str] = ()):
     rootfs = setup_rootfs(ctxt)
     for i, deb in enumerate(debs):
@@ -179,6 +185,18 @@ def rm_ro(func, path, _):
     """Clear readonly attribute and retry removal"""
     os.chmod(path, stat.S_IWRITE)
     func(path)
+
+
+@register_action()
+def rm_from_base(ctxt, path):
+    base = ctxt.edit_squashfs(get_squash_names(ctxt)[0])
+    base_path = f'{base}/{path}'
+    if os.path.exists(base_path):
+        if os.path.isdir(base_path):
+            shutil.rmtree(base_path, onerror=rm_ro)
+        else:
+            os.chmod(base_path, stat.S_IWRITE)
+            os.unlink(base_path)
 
 
 def rm_f(path):


### PR DESCRIPTION
Provide actions to copy a file to the base image and to remove a file from the base image.

This is useful when working with private ppas.