### PR TITLE
actions: restore support for relative paths

### DIFF
--- a/livefs_edit/actions.py
+++ b/livefs_edit/actions.py
@@ -169,6 +169,7 @@ def interpret_path(ctxt, path):
             get_squash_names(ctxt)[index],
             add_sys_mounts=index == 0)
         return os.path.join(base, path)
+    return ctxt.p(path)
 
 
 @register_action()


### PR DESCRIPTION
interpret_path() returns None when called for a relative path.

Relative paths should be interpreted as relative to the main temporary directory.

Fixes: 05774719e06a ("interpret $LAYER[n] as a prefix to paths in cp, rm")