### PR TITLE
cp: create destination path

### DIFF
--- a/livefs_edit/actions.py
+++ b/livefs_edit/actions.py
@@ -174,6 +174,7 @@ def interpret_path(ctxt, path):
 
 @register_action()
 def cp(ctxt, source, dest):
+    os.makedirs(interpret_path(ctxt, os.path.dirname(dest)), exist_ok=True)
     shutil.copy(interpret_path(ctxt, source), interpret_path(ctxt, dest))
 
 


### PR DESCRIPTION
For deep copies we may need to create the destination path.