### PR TITLE
modify cp action to support dir copy

### DIFF
--- a/livefs_edit/actions.py
+++ b/livefs_edit/actions.py
@@ -173,8 +173,13 @@ def interpret_path(ctxt, path):
 
 @register_action()
 def cp(ctxt, source, dest):
-    os.makedirs(interpret_path(ctxt, os.path.dirname(dest)), exist_ok=True)
-    shutil.copy(interpret_path(ctxt, source), interpret_path(ctxt, dest))
+    if os.path.isdir(interpret_path(ctxt, source)):
+        source_basename=os.path.basename(os.path.dirname(source))
+        os.makedirs(interpret_path(ctxt, os.path.dirname(dest))+"/"+source_basename, exist_ok=True)
+        shutil.copytree(interpret_path(ctxt, source), interpret_path(ctxt, dest)+"/"+source_basename, dirs_exist_ok = True)
+    else:
+        os.makedirs(interpret_path(ctxt, os.path.dirname(dest)), exist_ok=True)
+        shutil.copy(interpret_path(ctxt, source), interpret_path(ctxt, dest))
 
 
 @register_action()


### PR DESCRIPTION
Modified the `cp` action to support folder copy
It works like normal `cp -r`, source directory is copied to destination directory as a folder:
eg. source is `/home/ubuntu/setup` and destination is `new/iso/`, then folder `/home/ubuntu/setup` and subdirs/files within source dir will be  at `/cdrom/setup`.