### PR TITLE
Support cross arch modification

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,3 +301,14 @@ target system.
 Mount all squashfses in `new/iso/casper` at `old/{squash_name}` (this
 is mostly to make poking at ISOs in a subsequent interactive `--shell`
 action easier).
+
+## Cross-arch modification
+
+When working on an ISO with a different architecture than your host,
+you can pass `--arch_emulator` to specify which emulation binary to use
+when executing binary inside the ISO (such as packet installation) as a first
+argument of the command line.
+For example, for arm64 iso:
+```
+--arch_emulator qemu-aarch64-static
+````

--- a/livefs_edit/__main__.py
+++ b/livefs_edit/__main__.py
@@ -49,8 +49,13 @@ def main(argv=None):
         sys.exit(0)
 
     debug = False
+    arch_emulator = False
     if argv[0] == '--debug':
         debug = True
+        argv.pop(0)
+    if argv[0] == '--arch_emulator':
+        argv.pop(0)
+        arch_emulator = argv[0]
         argv.pop(0)
 
     sourcepath = argv[0]
@@ -63,7 +68,7 @@ def main(argv=None):
         destpath = destpath + '.new'
         inplace = True
 
-    ctxt = EditContext(sourcepath, debug=debug)
+    ctxt = EditContext(sourcepath, debug=debug, arch_emulator=arch_emulator)
 
     if argv[2] == '--action-yaml':
         calls = []

--- a/livefs_edit/actions.py
+++ b/livefs_edit/actions.py
@@ -186,7 +186,7 @@ def install_debs(ctxt, debs: List[str] = ()):
         with open(rootfs_path, 'x'):
             pass
         ctxt.run(['mount', '--bind', deb, rootfs_path])
-        ctxt.run(['chroot', rootfs, 'dpkg', '-i', deb_name])
+        ctxt.run(['dpkg', '-i', deb_name], chroot=rootfs)
         ctxt.run(['umount', rootfs_path])
         os.unlink(rootfs_path)
 
@@ -590,17 +590,17 @@ def unpack_initrd(ctxt, target='new/initrd'):
 @register_action()
 def install_packages(ctxt, packages: List[str]):
     base = ctxt.edit_squashfs(get_squash_names(ctxt)[0])
-    ctxt.run(['chroot', base, 'apt-get', 'update'])
+    ctxt.run(['apt-get', 'update'], chroot=base)
     env = os.environ.copy()
     env['DEBIAN_FRONTEND'] = 'noninteractive'
     env['LANG'] = 'C.UTF-8'
-    ctxt.run(['chroot', base, 'apt-get', 'install', '-y'] + packages, env=env)
+    ctxt.run(['apt-get', 'install', '-y'] + packages, env=env, chroot=base)
 
 
 @register_action()
 def add_apt_repository(ctxt, repo):
     base = ctxt.edit_squashfs(get_squash_names(ctxt)[0])
-    ctxt.run(['chroot', base, 'add-apt-repository', '-y', repo])
+    ctxt.run(['add-apt-repository', '-y', repo], chroot=base)
 
 
 @register_action()
@@ -693,15 +693,15 @@ echo 'LazyUnmount=yes' >> /run/systemd/system/usr-lib-modules.mount.d/lazy.conf
         'etc/apt/sources.list',
         f'deb [check-date=no] file:///mnt {codename} main restricted\n',
         )
-    ctxt.run(['chroot', new_kernel_layer.p(), 'apt-get', 'update'])
+    ctxt.run(['apt-get', 'update'], chroot=new_kernel_layer.p())
 
     # Install the new kernel.
     env = os.environ.copy()
     env['DEBIAN_FRONTEND'] = 'noninteractive'
     env['LANG'] = 'C.UTF-8'
     ctxt.run(
-        ['chroot', new_kernel_layer.p(), 'apt-get', 'install', '-y', meta_pkg],
-        env=env)
+        ['apt-get', 'install', '-y', meta_pkg],
+        env=env, chroot=new_kernel_layer.p())
 
     # Fish the kernel and initrd out and put them in the right place
     # on the ISO.

--- a/livefs_edit/context.py
+++ b/livefs_edit/context.py
@@ -69,7 +69,7 @@ class EditContext:
         self._mounts = []
         self._squash_mounts = {}
 
-    def run(self, cmd, check=True, **kw):
+    def run(self, cmd, check=True, chroot=False, **kw):
         if self.debug:
             msg = []
             for arg in cmd:
@@ -78,6 +78,10 @@ class EditContext:
                 msg.append(arg)
             msg = ' '.join(msg)
             self.log(f"running with check={check}, kw={kw}\n{self._indent}    {msg}")
+        if chroot:
+            cmd.insert(0,chroot)
+            cmd.insert(0,"chroot")
+
         cp = subprocess.run(cmd, check=check, **kw)
         if self.debug:
             msg = f"exit code {cp.returncode}"

--- a/livefs_edit/context.py
+++ b/livefs_edit/context.py
@@ -56,7 +56,7 @@ class OverlayMountpoint(_MountBase):
 
 class EditContext:
 
-    def __init__(self, source_path, *, debug=False):
+    def __init__(self, source_path, *, arch_emulator=False, debug=False):
         self.source_path = source_path
         self.debug = debug
         self._source_overlay = None
@@ -68,6 +68,8 @@ class EditContext:
         self._loops = []
         self._mounts = []
         self._squash_mounts = {}
+        if arch_emulator:
+            self._arch_emulator = arch_emulator
 
     def run(self, cmd, check=True, chroot=False, **kw):
         if self.debug:
@@ -81,6 +83,8 @@ class EditContext:
         if chroot:
             cmd.insert(0,chroot)
             cmd.insert(0,"chroot")
+            if self._arch_emulator:
+                cmd.insert(0, self._arch_emulator)
 
         cp = subprocess.run(cmd, check=check, **kw)
         if self.debug:


### PR DESCRIPTION
When editing an iso for another arch, we need an arch emulator to be able to execute binary inside the iso.
As it's not trivial to find this information and to link it to a corresponding binary, we rely on the user to pass it
as a command line argument such as:
```
livefs_edit --arch_emulator qemu-aarch64-static ./$BASEISONAME ./$OUTPUT
```

Solves #52 