### PR TITLE
Allow to set the initrd-path using an environment variable

### DIFF
--- a/livefs_edit/actions.py
+++ b/livefs_edit/actions.py
@@ -560,7 +560,9 @@ def unpack_initrd(ctxt, target='new/initrd'):
     target = ctxt.p(target)
     lower = ctxt.p('old/initrd')
     arch = ctxt.get_arch()
-    if arch == 's390x':
+    if 'INITRD_PATH' in os.environ:
+        initrd_path = os.environ['INITRD_PATH']
+    elif arch == 's390x':
         initrd_path = 'boot/initrd.ubuntu'
     else:
         initrd_path = 'casper/initrd'


### PR DESCRIPTION
When injecting a snap on an ISO that has multiple initrds (which define multiple layerfs-paths), having a way to select the initrd to use is convenient.

On Ubuntu 22.04 Server ISOs, we have a boot entry for "Ubuntu Server" and a second boot entry for "Ubuntu Server with HWE kernel". The entries respectively map to /casper/initrd and /casper/hwe-initrd.

Unconditionally injecting the snap using the layerfs-path from /casper/initrd makes it difficult to run ISO testing with the HWE kernel.

By making livefs-editor look for the presence of the INITRD_PATH variable (which we would set to /casper/hwe-initrd in our scenario), we have the opportunity to choose which boot entry is affected by the snap injection.