### PR TITLE
Add add-arch action

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,3 +308,8 @@ target system.
 Mount all squashfses in `new/iso/casper` at `old/{squash_name}` (this
 is mostly to make poking at ISOs in a subsequent interactive `--shell`
 action easier).
+
+### add-arch
+
+Add support for extra architectures (multi-arch). This is equivalent of running `dpkg --add-architecture <arch>`.
+It receives exactly one argument.

--- a/livefs_edit/actions.py
+++ b/livefs_edit/actions.py
@@ -491,8 +491,15 @@ def cache_for_dir(ctxt, dir):
         apt_pkg.config.clear(key)
     apt_pkg.config["Dir"] = dir
     apt_pkg.init_config()
+
     apt_pkg.config["APT::Architecture"] = ctxt.get_arch()
-    apt_pkg.config["APT::Architectures"] = ctxt.get_arch()
+
+    apt_pkg.config["APT::Architectures::"] = ctxt.get_arch()
+
+    # for multi-arch
+    for arch in ctxt.get_extra_arches():
+        apt_pkg.config["APT::Architectures::"] = arch
+
     apt_pkg.init_system()
     return Cache()
 
@@ -786,3 +793,9 @@ def mount_all_layers(ctxt, target='mounts'):
         squash_names = get_layer_part_names(squash.stem)
         lowers = [ctxt.mount_squash(name) for name in squash_names]
         ctxt.add_overlay(lowers, ctxt.p(f'{target}/{squash.stem}'))
+
+@register_action()
+def add_arch(ctxt, arch=None):
+    if arch is None:
+        raise Exception("argument to --arch is mandatory")
+    ctxt.add_arch(arch)

--- a/livefs_edit/context.py
+++ b/livefs_edit/context.py
@@ -69,6 +69,7 @@ class EditContext:
         self._mounts = []
         self._squash_mounts = {}
         self._xorriso_extra_args = []
+        self._extra_arches = []
 
     def run(self, cmd, check=True, **kw):
         if self.debug:
@@ -230,6 +231,12 @@ class EditContext:
         # Is this really the best way??
         with open(self.p('new/iso/.disk/info')) as fp:
             return fp.read().strip().split()[-2]
+
+    def add_arch(self, arch):
+        self._extra_arches.append(arch)
+
+    def get_extra_arches(self):
+        return self._extra_arches
 
     def get_suite(self):
         from deb822 import Deb822


### PR DESCRIPTION
Add action `--add_arch`, to be used similarly to `dpkg --add-architecture <arch>`.

In my case, I want to install `wine32` to a amd64 ubuntu 22.04.