### PR TITLE
Bugfix: new packages should be downloaded in the base layer

### DIFF
--- a/livefs_edit/actions.py
+++ b/livefs_edit/actions.py
@@ -515,9 +515,8 @@ def download_missing_pool_debs(ctxt, cache):
 @register_action()
 def add_packages_to_pool(ctxt, packages: List[str]):
     from apt.progress.text import AcquireProgress
-    fs = ctxt.mount_squash(get_squash_names(ctxt)[0])
-    overlay = ctxt.add_overlay(fs, ctxt.tmpdir())
-    cache = cache_for_dir(ctxt, overlay.p())
+    fs = ctxt.edit_squashfs(get_squash_names(ctxt)[0])
+    cache = cache_for_dir(ctxt, fs)
     with ctxt.logged(
             '** updating apt lists... **',
             '** updating apt lists done **'):


### PR DESCRIPTION
The use case for it is that the user might want to use `add-packages-to-pool` where the packages come from extra (non-ubuntu) repositories.

In my case, I setup the repositories in the base layer and notices they were not used in a further `add-package-to-pool` action, as `add-package-to-pool` was being executed in a different layer.

The Ubuntu Server version I am using is 22.04.

I've been using this change in production for some time now and it works well for me.

I still perform some extra steps to add extra repositories, but I haven't gotten yet a good interface for it on livefs-editor, so that will keep in a further pull request :-)