### PR TITLE
fix initrd handling on plucky+

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ description of `resign-pool`.
 
 Unpack the initrd using unmkinitramfs into `target` (contents will
 likely end up in subdirectories called things like `early`, `early2`
-and `main`, at least on amd64) and arrange for these to be repacked
+and `main`, or `cpioN`, at least on amd64) and arrange for these to be repacked
 into a replacement initrd for the modified ISO if any changes are made.
 
 ### add-apt-repository

--- a/livefs_edit/actions.py
+++ b/livefs_edit/actions.py
@@ -76,7 +76,7 @@ def _find_file_in_initrd(ctxt, relpath: str) -> Optional[str]:
     if potential_file.exists():
         return str(potential_file)
 
-    for subdir in dir.iterdir():
+    for subdir in sorted(dir.iterdir(), reverse=True):
         if not subdir.is_dir():
             continue
         potential_file = subdir / relpath

--- a/livefs_edit/actions.py
+++ b/livefs_edit/actions.py
@@ -597,10 +597,12 @@ def unpack_initrd(ctxt, target='new/initrd'):
                 return
             with ctxt.logged(f'repacking initrd to {initrd_path} ...', 'done'):
                 with open(ctxt.p(f'new/iso/{initrd_path}'), 'wb') as out:
-                    for dir in sorted(os.listdir(target)):
+                    dirs = sorted(pathlib.Path(target).iterdir())
+                    for idx, dir in enumerate(dirs):
+                        assert dir.is_dir()
+                        compress = idx == len(dirs) - 1
                         with ctxt.logged(f'packing {dir}'):
-                            pack_for_initrd(
-                                f'{target}/{dir}', dir == "main", out)
+                            pack_for_initrd(str(dir), compress, out)
 
         ctxt.add_pre_repack_hook(_pre_repack_multi)
     else:

--- a/livefs_edit/actions.py
+++ b/livefs_edit/actions.py
@@ -590,7 +590,8 @@ def unpack_initrd(ctxt, target='new/initrd'):
     ctxt.run(['unmkinitramfs', ctxt.p(f'new/iso/{initrd_path}'), lower])
     overlay = ctxt.add_overlay(lower, target)
 
-    if 'early' in os.listdir(target):
+    multipart_dirs = set(['early', 'cpio1'])
+    if bool(multipart_dirs & set(os.listdir(target))):
         def _pre_repack_multi():
             if overlay.unchanged():
                 return

--- a/livefs_edit/actions.py
+++ b/livefs_edit/actions.py
@@ -70,15 +70,19 @@ class LayerfsLoc(enum.Enum):
     INITRD = enum.auto()
 
 
+def get_layer_conf_path(ctxt) -> str:
+    initrd_path = unpack_initrd(ctxt)
+    if 'main' in os.listdir(initrd_path):
+        initrd_path = initrd_path + '/main'
+    return f'{initrd_path}/conf/conf.d/default-layer.conf'
+
+
 @cached
 def get_layerfs_path(ctxt):
     cmdline_val = get_cmdline_arg(ctxt, 'layerfs-path')
     if cmdline_val is not None:
         return cmdline_val, LayerfsLoc.CMDLINE
-    initrd_path = unpack_initrd(ctxt)
-    if 'main' in os.listdir(initrd_path):
-        initrd_path = initrd_path + '/main'
-    layer_conf_path = f'{initrd_path}/conf/conf.d/default-layer.conf'
+    layer_conf_path = get_layer_conf_path(ctxt)
     if os.path.exists(layer_conf_path):
         with open(layer_conf_path) as fp:
             for line in fp:
@@ -144,10 +148,7 @@ def setup_rootfs(ctxt, target='rootfs'):
                 arg=f"layerfs-path={new_squash_name}.squashfs",
                 persist=False)
         elif layerfs_loc == LayerfsLoc.INITRD:
-            initrd_path = unpack_initrd(ctxt)
-            if 'main' in os.listdir(initrd_path):
-                initrd_path = initrd_path + '/main'
-            layer_conf_path = f'{initrd_path}/conf/conf.d/default-layer.conf'
+            layer_conf_path = get_layer_conf_path(ctxt)
             with open(layer_conf_path, 'w') as fp:
                 fp.write(
                     f"LAYERFS_PATH={new_squash_name}.squashfs\n")


### PR DESCRIPTION
Per https://salsa.debian.org/kernel-team/initramfs-tools/-/commit/cb0618177b26b8c9bfab059a04f6007e5ef756d9, which recently migrated to plucky, initrds may not be unpacked with the naming convention early1..n and main, and now go by the naming convention cpio1..m.   The last one is still the compressed one but has no special name, so would be cpio4 if there were 4 parts total.

Update various parts of actions.py that have dependencies on the specific naming convention 'early' and 'main' and generalize them to not depend on specific names.

Fixes: #71 