### PR TITLE
context.py: illegal import of deb822

### DIFF
--- a/livefs_edit/context.py
+++ b/livefs_edit/context.py
@@ -23,6 +23,7 @@ import shlex
 import shutil
 import subprocess
 import tempfile
+from debian import deb822
 
 
 class _MountBase:
@@ -232,10 +233,9 @@ class EditContext:
             return fp.read().strip().split()[-2]
 
     def get_suite(self):
-        from deb822 import Deb822
         paths = glob.glob(self.p('old/iso/dists/*/Release'))
         with open(paths[0]) as fp:
-            release = Deb822(fp)
+            release = deb822.Deb822(fp)
         return release['Suite']
 
     def edit_squashfs(self, name, *, add_sys_mounts=True):


### PR DESCRIPTION
Pylint shows these coding errors:

```
  livefs_edit/context.py:235:8:
    E0401: Unable to import 'deb822' (import-error)
    C0415: Import outside toplevel (deb822.Deb822)
           (import-outside-toplevel)
```

'deb822' can be imported from 'debian'.

Fixes: 4d5ff3104793 ("rewrite get_suite in an excessively fancy way")