### PR TITLE
Bugfix: prevent deb packages explicitly requested to be downloaded from not being downloaded

### DIFF
--- a/livefs_edit/actions.py
+++ b/livefs_edit/actions.py
@@ -516,7 +516,7 @@ def cache_for_dir(ctxt, dir):
     return Cache()
 
 
-def download_missing_pool_debs(ctxt, cache):
+def download_missing_pool_debs(ctxt, packages):
     tdir = ctxt.tmpdir()
     pool_debs = set()
     for dirpath, dirnames, filenames in os.walk(ctxt.p('new/iso/pool')):
@@ -524,7 +524,7 @@ def download_missing_pool_debs(ctxt, cache):
             if fname.endswith('.deb'):
                 pool_debs.add(fname)
     debs = []
-    for p in cache.get_changes():
+    for p in packages:
         fname = os.path.basename(p.candidate.filename)
         if fname not in pool_debs:
             debs.append(p.candidate.fetch_binary(tdir))
@@ -542,6 +542,9 @@ def add_packages_to_pool(ctxt, packages: List[str]):
             '** updating apt lists done **'):
         cache.update(AcquireProgress())
     cache.open()
+
+    changes = set()
+
     for p in packages:
         with ctxt.logged(f'marking {p} for installation'):
             if "=" in p:
@@ -551,7 +554,8 @@ def add_packages_to_pool(ctxt, packages: List[str]):
                 package.mark_install()
             else:
                 cache[p].mark_install()
-    debs = download_missing_pool_debs(ctxt, cache)
+        changes = changes.union(set(cache.get_changes()))
+    debs = download_missing_pool_debs(ctxt, changes)
     add_debs_to_pool(ctxt, debs=debs)
 
 


### PR DESCRIPTION
On my setup, I am customizing ubuntu server 22.04.5 (yes, an old version) with some i386 packages (see !67) and I need to generate an ISO image with all the dependencies on it, so that it can used to install some servers offline, in an environment without internet connection.

I've noticed that when I run livefs-editor `--add-debs-to-pool chrony wine32:i386`, when `wine32:i386` is marked to install, it removes `chrony` from the list of packages to be installed (in our case, to be downloaded), and I really have no idea why it happens, as there seems to be no conflicts between `wine32:i386` and `chrony` if you install them via `apt`.

As a result, I end up with an ISO image without the chrony package, which fails to install offline, as on my autoinstall file explicitly asks chrony to be installed.

Regardless of chrony or wine, this shows that it's possible that a package removes another package from the list of packages to be downloaded.

To workaround it, this PR changes the way the changes are computed, by storing the packages to be downloaded in a set, which never shrinks, on which no elements can be removed from it, preventing explicitly requested downloads of being removed from the changeset.

This of course introduces some performance issue in case the list of packages to be download is large, but I really believe such performance hit is negligible, as operations on `set()` are quite fast.

As here we are handling only the downloads, it's up to the user to worry during the installation process whether there are conflicts or not.

I've been using this change in production for some time now and it seems to work well me, but I am not sure whether it'll break anyone else's setup.