### PR TITLE
pyproject.toml: correct search path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
-where = ["livefs_edit"]
+where = ["."]
 
 [project]
 name = "livefs-edit"


### PR DESCRIPTION
tool.setuptools.packages.find must look into the current directory to avoid an error

    ModuleNotFoundError: No module named 'livefs_edit'